### PR TITLE
chore(build): Update build & deps

### DIFF
--- a/build/index.full.js
+++ b/build/index.full.js
@@ -93,7 +93,7 @@ export {
   isNavigationCommand,
   Redirect,
   RedirectToRoute,
-  pipelineStatus,
+  PipelineStatus,
   Pipeline,
   RouterConfiguration,
   activationStrategy,

--- a/build/index.no-loader.full.js
+++ b/build/index.no-loader.full.js
@@ -92,7 +92,7 @@ export {
   isNavigationCommand,
   Redirect,
   RedirectToRoute,
-  pipelineStatus,
+  PipelineStatus,
   Pipeline,
   RouterConfiguration,
   activationStrategy,

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -167,4 +167,15 @@ export default [
       })
     ]
   },
-]
+].map(config => {
+  config.plugins.unshift({
+    resolveId(importee) {
+      return importee === 'aurelia-templating-binding'
+        ? './node_modules/aurelia-templating-binding/dist/es2015/aurelia-templating-binding.js'
+        : importee === 'aurelia-route-recognizer'
+          ? './node_modules/aurelia-route-recognizer/dist/es2015/aurelia-route-recognizer.js'
+          : null;
+    }
+  })
+  return config;
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-script",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -985,16 +985,18 @@
       }
     },
     "aurelia-route-recognizer": {
-      "version": "git+https://github.com/aurelia/route-recognizer.git#79d3e6f6c0d83cf32f81bafc83be1b20af52d032",
-      "from": "git+https://github.com/aurelia/route-recognizer.git",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/aurelia-route-recognizer/-/aurelia-route-recognizer-1.3.2.tgz",
+      "integrity": "sha512-nBlNSVmN1aX6KpzCzbISrolX8ETqt/Otet+Lp2qpI98ib9ZoSXVrFDZSgPaOSJaUs3A0r+felLSqBm3NNHqy4g==",
       "dev": true,
       "requires": {
         "aurelia-path": "^1.0.0"
       }
     },
     "aurelia-router": {
-      "version": "git+https://github.com/aurelia/router.git#3d7c24d2980f3db64ee18153090eebd014cb9769",
-      "from": "git+https://github.com/aurelia/router.git",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/aurelia-router/-/aurelia-router-1.7.1.tgz",
+      "integrity": "sha512-P6xxikeHHzVLxpZD8tvTwGJmEHY3M1MPTiIYzk32s85scd4kQ77FgQWo77ujYNv6hjrExifLFbrxIB7pUEziIQ==",
       "dev": true,
       "requires": {
         "aurelia-dependency-injection": "^1.0.0",
@@ -1002,7 +1004,7 @@
         "aurelia-history": "^1.1.0",
         "aurelia-logging": "^1.0.0",
         "aurelia-path": "^1.0.0",
-        "aurelia-route-recognizer": "^1.2.0"
+        "aurelia-route-recognizer": "^1.3.2"
       }
     },
     "aurelia-task-queue": {
@@ -1031,8 +1033,9 @@
       }
     },
     "aurelia-templating-binding": {
-      "version": "git+https://github.com/aurelia/templating-binding.git#8ec29ef02270d707095ac53234385d1495d7ef20",
-      "from": "git+https://github.com/aurelia/templating-binding.git",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/aurelia-templating-binding/-/aurelia-templating-binding-1.5.3.tgz",
+      "integrity": "sha512-HGfPfmykVdMSCb/ugfB2eQx0CmgUy0XnQOr1i3eenOW4ZN9sg7UNtxNhWorhXgKnUPf13XleA/HeIkwBnILATA==",
       "dev": true,
       "requires": {
         "aurelia-binding": "^2.0.0",
@@ -1058,12 +1061,13 @@
       }
     },
     "aurelia-templating-router": {
-      "version": "git+https://github.com/aurelia/templating-router.git#69bc825fce2cff2c0541482c72ca73120bdbada4",
-      "from": "git+https://github.com/aurelia/templating-router.git",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/aurelia-templating-router/-/aurelia-templating-router-1.4.0.tgz",
+      "integrity": "sha512-qjVPVoDpUc9T0rHpXtevD433z+ent/n9cG2Jc1rWqVOt+3n6tGMOR+GgrZnv3q6P0DMZqy/pz6n3th5Y/aK6LA==",
       "dev": true,
       "requires": {
         "aurelia-binding": "^2.0.0",
-        "aurelia-dependency-injection": "^1.0.0",
+        "aurelia-dependency-injection": "^1.3.0",
         "aurelia-logging": "^1.0.0",
         "aurelia-metadata": "^1.0.0",
         "aurelia-pal": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "scripts": {
     "build": "rollup -c ./build/rollup.config.js --environment ROUTER:false",
     "build:full": "rollup -c ./build/rollup.config.js",
+    "minify:no-loader:es5:umd": "terser ./dist/aurelia_no_loader.es5.umd.js -o ./dist/aurelia_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
+    "minify:router:no-loader:es5:umd": "terser ./dist/aurelia_router_no_loader.es5.umd.js -o ./dist/aurelia_router_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
     "minify:umd": "terser ./dist/aurelia.umd.js -o ./dist/aurelia.umd.min.js --config-file ./build/terser.config.json",
     "minify:esm": "terser ./dist/aurelia.esm.js -o ./dist/aurelia.esm.min.js --config-file ./build/terser.config.json",
     "minify:router:umd": "terser ./dist/aurelia_router.umd.js -o ./dist/aurelia_router.umd.min.js --config-file ./build/terser.config.json",
@@ -31,7 +33,7 @@
     "minify:router:no-loader:umd": "terser ./dist/aurelia_router_no_loader.es5.umd.js -o ./dist/aurelia_router_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
     "bundle": "npm run build:full",
     "postbundle": "npm run minify",
-    "minify": "npm run minify:esm && npm run minify:umd && npm run minify:router:umd && npm run minify:router:esm && minify:no-loader:umd && minify:router:no-loader:umd"
+    "minify": "npm run minify:esm && npm run minify:umd && npm run minify:router:umd && npm run minify:router:esm && minify:no-loader:umd && minify:router:no-loader:umd && minify:no-loader:es5:umd && minify:router:no-loader:es5:umd"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",
@@ -52,13 +54,13 @@
     "aurelia-pal-browser": "^1.8.1",
     "aurelia-path": "git+https://github.com/aurelia/path.git",
     "aurelia-polyfills": "git+https://github.com/aurelia/polyfills.git",
-    "aurelia-route-recognizer": "git+https://github.com/aurelia/route-recognizer.git",
-    "aurelia-router": "git+https://github.com/aurelia/router.git",
+    "aurelia-route-recognizer": "^1.3.2",
+    "aurelia-router": "^1.7.1",
     "aurelia-task-queue": "^1.3.2",
     "aurelia-templating": "^1.10.1",
-    "aurelia-templating-binding": "git+https://github.com/aurelia/templating-binding.git",
+    "aurelia-templating-binding": "^1.5.3",
     "aurelia-templating-resources": "^1.7.2",
-    "aurelia-templating-router": "git+https://github.com/aurelia/templating-router.git",
+    "aurelia-templating-router": "^1.4.0",
     "rollup": "^1.1.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -23,17 +23,15 @@
   "scripts": {
     "build": "rollup -c ./build/rollup.config.js --environment ROUTER:false",
     "build:full": "rollup -c ./build/rollup.config.js",
-    "minify:no-loader:es5:umd": "terser ./dist/aurelia_no_loader.es5.umd.js -o ./dist/aurelia_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
-    "minify:router:no-loader:es5:umd": "terser ./dist/aurelia_router_no_loader.es5.umd.js -o ./dist/aurelia_router_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
     "minify:umd": "terser ./dist/aurelia.umd.js -o ./dist/aurelia.umd.min.js --config-file ./build/terser.config.json",
     "minify:esm": "terser ./dist/aurelia.esm.js -o ./dist/aurelia.esm.min.js --config-file ./build/terser.config.json",
     "minify:router:umd": "terser ./dist/aurelia_router.umd.js -o ./dist/aurelia_router.umd.min.js --config-file ./build/terser.config.json",
     "minify:router:esm": "terser ./dist/aurelia_router.esm.js -o ./dist/aurelia_router.esm.min.js --config-file ./build/terser.config.json",
-    "minify:no-loader:umd": "terser ./dist/aurelia_no_loader.es5.umd.js -o ./dist/aurelia_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
-    "minify:router:no-loader:umd": "terser ./dist/aurelia_router_no_loader.es5.umd.js -o ./dist/aurelia_router_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
+    "minify:no-loader:es5:umd": "terser ./dist/aurelia_no_loader.es5.umd.js -o ./dist/aurelia_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
+    "minify:router:no-loader:es5:umd": "terser ./dist/aurelia_router_no_loader.es5.umd.js -o ./dist/aurelia_router_no_loader.es5.umd.min.js --config-file ./build/terser.es5.config.json",
     "bundle": "npm run build:full",
     "postbundle": "npm run minify",
-    "minify": "npm run minify:esm && npm run minify:umd && npm run minify:router:umd && npm run minify:router:esm && minify:no-loader:umd && minify:router:no-loader:umd && minify:no-loader:es5:umd && minify:router:no-loader:es5:umd"
+    "minify": "npm run minify:esm && npm run minify:umd && npm run minify:router:umd && npm run minify:router:esm && minify:no-loader:es5:umd && minify:router:no-loader:es5:umd"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",


### PR DESCRIPTION
There was an issues with some package fields and a accidental breaking change, though minor in Router (my fault) that caused build to stop working. `pipelineStatus` -> `PipelineStatus`. This was never properly documented so I guess we will not have issues, but if folks complain, we can add an alias export.

@EisenbergEffect ready to go