### PR TITLE
fix(shortcut-fn): don't use async fn, fix version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo is the home for Aurelia's concatenated script-tag-ready build.
 In the good old day, you chuck in a script tag into your html and start writing app. Aurelia Script is a way to help you return to that, with Aurelia. Simply add:
 
 ```html
-  <script src='https://unpkg.com/aurelia-script@1.4.0'></script>
+  <script src='https://unpkg.com/aurelia-script@1.5.1'></script>
 ```
 
 into your main html and you are ready to go, like the following:

--- a/build/index.quick-start.js
+++ b/build/index.quick-start.js
@@ -32,10 +32,9 @@ const createAndStart = (options = {}) => {
  * @param {QuickStartOptions} options
  * @returns {Aurelia} the running Aurelia instance
  */
-export async function start(options = {}) {
-  const aurelia = await createAndStart(options);
-  await aurelia.setRoot(options.root || 'app.js', options.host || document.body);
-  return aurelia;
+export function start(options = {}) {
+  return createAndStart(options)
+    .then(aurelia => aurelia.setRoot(options.root || 'app.js', options.host || document.body));
 }
 
 /**
@@ -43,12 +42,14 @@ export async function start(options = {}) {
  * @param {QuickEnhanceOptions} options Configuration for enhancing a DOM tree
  * @returns {View} the enhanced View by selected options
  */
-export async function enhance(options = {}) {
-  const aurelia = await createAndStart(options);
-  if (typeof options.root === 'function') {
-    options.root = aurelia.container.get(options.root);
-  }
-  return aurelia.enhance(options.root || {}, options.host || document.body);
+export function enhance(options = {}) {
+  return createAndStart(options)
+    .then(aurelia => {
+      if (typeof options.root === 'function') {
+        options.root = aurelia.container.get(options.root);
+      }
+      return aurelia.enhance(options.root || {}, options.host || document.body);
+    });
 }
 
 /** @typed ConfigureFn


### PR DESCRIPTION
Avoid using async/await as with babel compilation, it requires a runtime, and the fns are dead simple so just use normal promise

@EisenbergEffect 