### PR TITLE
chore(dist-es5): add polyfills by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo is the home for Aurelia's concatenated script-tag-ready build.
 In the good old day, you chuck in a script tag into your html and start writing app. Aurelia Script is a way to help you return to that, with Aurelia. Simply add:
 
 ```html
-  <script src='https://unpkg.com/aurelia-script@1.5.1'></script>
+  <script src='https://unpkg.com/aurelia-script@1.5.2'></script>
 ```
 
 into your main html and you are ready to go, like the following:

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -97,15 +97,6 @@ export default [
 
     // external: externalLibs,
     plugins: [
-      replace({
-        FEATURE_NO_ES2015: true,
-        FEATURE_NO_ES2016: true,
-        // Need for Reflect metadata
-        FEATURE_NO_ESNEXT: undefined,
-        FEATURE_NO_IE: true,
-        FEATURE_NO_UNPARSER: true,
-        FEATURE_ROUTER: process.env.ROUTER === false ? undefined : true
-      }),
 
       nodeResolve({
         // jsnext: true,
@@ -138,16 +129,6 @@ export default [
 
     // external: externalLibs,
     plugins: [
-      replace({
-        FEATURE_NO_ES2015: true,
-        FEATURE_NO_ES2016: true,
-        // Need for Reflect metadata
-        FEATURE_NO_ESNEXT: undefined,
-        FEATURE_NO_IE: true,
-        FEATURE_NO_UNPARSER: true,
-        FEATURE_ROUTER: process.env.ROUTER === false ? undefined : true
-      }),
-
       nodeResolve({
         // jsnext: true,
         // main: true


### PR DESCRIPTION
@EisenbergEffect tested locally the todomvc app on my machine, in IE11 and realized that it's still missing this after the loader issue. But this should be the last. Please release 1.5.2